### PR TITLE
Added second agent and pen test

### DIFF
--- a/agents/capacity_agent.py
+++ b/agents/capacity_agent.py
@@ -1,0 +1,206 @@
+# agents/capacity_agent.py
+# ════════════════════════════════════════════════════════════════════════
+# ZERO LLM calls. ZERO external packages. Pure Python math.
+# No google-genai. No pydantic. No numpy. Just arithmetic.
+# ════════════════════════════════════════════════════════════════════════
+
+from __future__ import annotations
+
+# ── RUL thresholds ────────────────────────────────────────────────────────────
+RUL_OFFLINE_THRESHOLD  = 15    # RUL ≤ 15  → OFFLINE
+RUL_DEGRADED_THRESHOLD = 30    # RUL ≤ 30  → DEGRADED (and > 15)
+DEGRADED_CAPACITY_FACTOR = 0.5 # DEGRADED machines run at 50% available time
+
+# ── Healthy baseline for breakeven risk calculation ───────────────────────────
+# Computed once from the known healthy total (595 units / 40 hours).
+# Breakeven risk fires when machine_req exceeds this by more than 7%.
+_HEALTHY_TOTAL_PD = 595
+_HEALTHY_TOTAL_T  = 40.0
+HEALTHY_BASELINE_REQ  = _HEALTHY_TOTAL_PD / _HEALTHY_TOTAL_T  # = 14.875
+BREAKEVEN_THRESHOLD   = HEALTHY_BASELINE_REQ * 1.07           # ≈ 15.92
+
+# ── Machine registry ──────────────────────────────────────────────────────────
+# This is mutable state. Each update_capacity() call modifies it in-place.
+# reset_all() restores it to starting values.
+# Machine IDs are 1-indexed (1–5) to match what the professor says: "Machine 4"
+MACHINES: dict[int, dict] = {
+    1: {
+        "name": "CNC-Alpha",
+        "base_time": 8.0,
+        "product_demand": 120,
+        "available_time": 8.0,
+        "rul": 999.0,
+        "status": "ONLINE",
+    },
+    2: {
+        "name": "CNC-Beta",
+        "base_time": 8.0,
+        "product_demand": 95,
+        "available_time": 8.0,
+        "rul": 999.0,
+        "status": "ONLINE",
+    },
+    3: {
+        "name": "Press-Gamma",
+        "base_time": 8.0,
+        "product_demand": 140,
+        "available_time": 8.0,
+        "rul": 999.0,
+        "status": "ONLINE",
+    },
+    4: {
+        "name": "Lathe-Delta",
+        "base_time": 8.0,
+        "product_demand": 110,
+        "available_time": 8.0,
+        "rul": 999.0,
+        "status": "ONLINE",
+    },
+    5: {
+        "name": "Mill-Epsilon",
+        "base_time": 8.0,
+        "product_demand": 130,
+        "available_time": 8.0,
+        "rul": 999.0,
+        "status": "ONLINE",
+    },
+}
+
+
+# ── Core function ─────────────────────────────────────────────────────────────
+
+def update_capacity(machine_id: int, new_rul: float) -> dict:
+    """
+    Update one machine's RUL and recompute factory-wide capacity metrics.
+    Modifies MACHINES[machine_id] in-place (permanent for this session).
+
+    Called by agent_loop.py after predict_rul() returns a value.
+
+    Args:
+        machine_id: 1–5 (matches professor's "Machine 4")
+        new_rul:    float from DL oracle — e.g. 12.0, 22.5, 45.0
+
+    Returns:
+        dict with all capacity metrics (see data contract above)
+
+    Raises:
+        KeyError: if machine_id not in 1–5
+    """
+    if machine_id not in MACHINES:
+        raise KeyError(
+            f"machine_id {machine_id} not found. "
+            f"Valid IDs are: {sorted(MACHINES.keys())}"
+        )
+
+    machine = MACHINES[machine_id]
+    machine["rul"] = new_rul
+
+    # ── Step 1: Determine new status ─────────────────────────────────────────
+    if new_rul <= RUL_OFFLINE_THRESHOLD:
+        machine["available_time"] = 0.0
+        machine["status"] = "OFFLINE"
+
+    elif new_rul <= RUL_DEGRADED_THRESHOLD:
+        machine["available_time"] = machine["base_time"] * DEGRADED_CAPACITY_FACTOR
+        machine["status"] = "DEGRADED"
+
+    else:
+        machine["available_time"] = machine["base_time"]
+        machine["status"] = "ONLINE"
+
+    # ── Step 2: Factory-wide metrics ──────────────────────────────────────────
+    total_T  = sum(m["available_time"] for m in MACHINES.values())
+    total_PD = sum(m["product_demand"]  for m in MACHINES.values())  # always 595
+
+    # Guard against all machines offline (division by zero)
+    if total_T > 0:
+        machine_req = total_PD / total_T
+    else:
+        machine_req = float("inf")
+
+    max_T        = len(MACHINES) * 8.0    # = 40.0 hrs
+    capacity_pct = (total_T / max_T) * 100
+
+    breakeven_risk = (
+        machine_req == float("inf")
+        or machine_req > BREAKEVEN_THRESHOLD
+    )
+
+    return {
+        "machine_id":     machine_id,
+        "machine_name":   machine["name"],
+        "status":         machine["status"],
+        "rul":            round(new_rul, 1),
+        "total_T":        round(total_T, 2),
+        "total_PD":       total_PD,
+        "machine_req":    round(machine_req, 3) if machine_req != float("inf") else float("inf"),
+        "capacity_pct":   round(capacity_pct, 1),
+        "breakeven_risk": breakeven_risk,
+    }
+
+
+# ── Read-only helpers ─────────────────────────────────────────────────────────
+
+def get_all_machine_statuses() -> list[dict]:
+    """
+    Current status of all 5 machines.
+    Called by agent_loop.py to populate the UI dashboard panel.
+
+    Returns:
+        List of dicts, one per machine, sorted by machine_id.
+    """
+    return [
+        {
+            "id":             mid,
+            "name":           m["name"],
+            "status":         m["status"],
+            "rul":            round(m["rul"], 1),
+            "available_time": m["available_time"],
+            "base_time":      m["base_time"],
+        }
+        for mid, m in sorted(MACHINES.items())
+    ]
+
+
+def get_factory_snapshot() -> dict:
+    """
+    Current factory-wide metrics without updating any machine.
+    Used by the dashboard for a live readout between fault injections.
+    """
+    total_T  = sum(m["available_time"] for m in MACHINES.values())
+    total_PD = sum(m["product_demand"]  for m in MACHINES.values())
+
+    if total_T > 0:
+        machine_req = total_PD / total_T
+    else:
+        machine_req = float("inf")
+
+    max_T        = len(MACHINES) * 8.0
+    capacity_pct = (total_T / max_T) * 100
+    breakeven_risk = (
+        machine_req == float("inf")
+        or machine_req > BREAKEVEN_THRESHOLD
+    )
+
+    return {
+        "total_T":        round(total_T, 2),
+        "total_PD":       total_PD,
+        "machine_req":    round(machine_req, 3) if machine_req != float("inf") else float("inf"),
+        "capacity_pct":   round(capacity_pct, 1),
+        "breakeven_risk": breakeven_risk,
+    }
+
+
+# ── State management ──────────────────────────────────────────────────────────
+
+def reset_all() -> None:
+    """
+    Restore all machines to ONLINE / full capacity / RUL=999.
+    Called by the Terminal when the professor presses Ctrl+R to restart the demo.
+    Does not reset OFFLINE_MODE in agent_loop.py — call reset_offline_mode()
+    separately if needed.
+    """
+    for m in MACHINES.values():
+        m["available_time"] = m["base_time"]
+        m["rul"]            = 999.0
+        m["status"]         = "ONLINE"

--- a/tests/test_agent2.py
+++ b/tests/test_agent2.py
@@ -1,0 +1,257 @@
+"""
+tests/test_agent2.py
+Agent 2 — Capacity Agent: automated tests.
+
+Run from project ROOT:
+    python tests/test_agent2.py
+    python tests/test_agent2.py --save
+"""
+
+import sys
+import argparse
+from io import StringIO
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from agents.capacity_agent import (
+    update_capacity,
+    get_all_machine_statuses,
+    get_factory_snapshot,
+    reset_all,
+    MACHINES,
+    HEALTHY_BASELINE_REQ,
+    BREAKEVEN_THRESHOLD,
+    RUL_OFFLINE_THRESHOLD,
+    RUL_DEGRADED_THRESHOLD,
+)
+
+results: list[dict] = []
+output_buffer = StringIO()
+
+
+def log(msg: str):
+    print(msg)
+    output_buffer.write(msg + "\n")
+
+
+def record(name: str, passed: bool, detail: str = ""):
+    results.append({"name": name, "passed": passed, "detail": detail})
+    status = "✓" if passed else "✗"
+    line = f"  {status} {name}"
+    if detail:
+        line += f"  [{detail}]"
+    log(line)
+
+
+def approx(a: float, b: float, tol: float = 0.01) -> bool:
+    if a == float("inf") and b == float("inf"):
+        return True
+    return abs(a - b) <= tol
+
+
+# ─────────────────────────────────────────────────────────────────────────────
+
+def suite_constants():
+    log("\\n── SUITE 1: Constants and baseline ──────────────────────────────────")
+    record("HEALTHY_BASELINE_REQ ≈ 14.875",
+           approx(HEALTHY_BASELINE_REQ, 14.875, 0.001))
+    record("BREAKEVEN_THRESHOLD ≈ 15.916",
+           approx(BREAKEVEN_THRESHOLD, 14.875 * 1.07, 0.001))
+    record("5 machines in MACHINES dict", len(MACHINES) == 5)
+    record("All machines start ONLINE",
+           all(m["status"] == "ONLINE" for m in MACHINES.values()))
+    record("All base_time == 8.0",
+           all(m["base_time"] == 8.0 for m in MACHINES.values()))
+    record("Total product demand == 595",
+           sum(m["product_demand"] for m in MACHINES.values()) == 595)
+
+
+def suite_status_transitions():
+    log("\\n── SUITE 2: RUL → status transitions ───────────────────────────────")
+    reset_all()
+
+    # Boundary conditions
+    cases = [
+        (RUL_OFFLINE_THRESHOLD,       "OFFLINE"),   # exactly at threshold
+        (RUL_OFFLINE_THRESHOLD - 0.1, "OFFLINE"),   # just below
+        (RUL_OFFLINE_THRESHOLD + 0.1, "DEGRADED"),  # just above
+        (RUL_DEGRADED_THRESHOLD,      "DEGRADED"),  # exactly at threshold
+        (RUL_DEGRADED_THRESHOLD - 0.1,"DEGRADED"),  # just below
+        (RUL_DEGRADED_THRESHOLD + 0.1,"ONLINE"),    # just above
+        (999.0,                        "ONLINE"),    # far above
+    ]
+    for rul, expected_status in cases:
+        reset_all()
+        report = update_capacity(1, rul)
+        passed = report["status"] == expected_status
+        record(
+            f"RUL={rul:.1f} → {expected_status}",
+            passed,
+            f"got {report['status']}" if not passed else ""
+        )
+
+    # DEGRADED capacity is 50%
+    reset_all()
+    update_capacity(1, 25.0)   # DEGRADED
+    record("DEGRADED machine available_time == 4.0 hrs",
+            MACHINES[1]["available_time"] == 4.0,
+            f"got {MACHINES[1]['available_time']}")
+
+    # OFFLINE capacity is 0
+    reset_all()
+    update_capacity(1, 10.0)   # OFFLINE
+    record("OFFLINE machine available_time == 0.0 hrs",
+            MACHINES[1]["available_time"] == 0.0,
+            f"got {MACHINES[1]['available_time']}")
+
+
+def suite_capacity_math():
+    log("\\n── SUITE 3: Factory-wide capacity math ──────────────────────────────")
+    reset_all()
+
+    # All ONLINE baseline
+    snap = get_factory_snapshot()
+    record("All ONLINE: total_T == 40.0",       approx(snap["total_T"], 40.0))
+    record("All ONLINE: machine_req ≈ 14.875",  approx(snap["machine_req"], 14.875))
+    record("All ONLINE: capacity_pct == 100.0", approx(snap["capacity_pct"], 100.0))
+    record("All ONLINE: breakeven_risk == False", snap["breakeven_risk"] == False)
+
+    # Machine 4 DEGRADED (RUL=22)
+    reset_all()
+    r = update_capacity(4, 22.0)
+    record("M4 DEGRADED: total_T == 36.0",       approx(r["total_T"], 36.0))
+    record("M4 DEGRADED: machine_req ≈ 16.528",  approx(r["machine_req"], 16.528))
+    record("M4 DEGRADED: capacity_pct == 90.0",  approx(r["capacity_pct"], 90.0))
+    record("M4 DEGRADED: breakeven_risk == True", r["breakeven_risk"] == True)
+
+    # Machine 4 OFFLINE (RUL=12)
+    reset_all()
+    r = update_capacity(4, 12.0)
+    record("M4 OFFLINE: total_T == 32.0",        approx(r["total_T"], 32.0))
+    record("M4 OFFLINE: machine_req ≈ 18.594",   approx(r["machine_req"], 18.594))
+    record("M4 OFFLINE: capacity_pct == 80.0",   approx(r["capacity_pct"], 80.0))
+    record("M4 OFFLINE: breakeven_risk == True",  r["breakeven_risk"] == True)
+
+    # Stacked faults: M3 and M4 both OFFLINE
+    reset_all()
+    update_capacity(4, 12.0)
+    r = update_capacity(3, 8.0)
+    record("M3+M4 OFFLINE: total_T == 24.0",     approx(r["total_T"], 24.0))
+    record("M3+M4 OFFLINE: machine_req ≈ 24.792",approx(r["machine_req"], 24.792))
+    record("M3+M4 OFFLINE: capacity_pct == 60.0",approx(r["capacity_pct"], 60.0))
+
+    # All OFFLINE edge case
+    reset_all()
+    for mid in range(1, 6):
+        update_capacity(mid, 5.0)
+    snap = get_factory_snapshot()
+    record("All OFFLINE: total_T == 0.0",            approx(snap["total_T"], 0.0))
+    record("All OFFLINE: machine_req == inf",         snap["machine_req"] == float("inf"))
+    record("All OFFLINE: capacity_pct == 0.0",        approx(snap["capacity_pct"], 0.0))
+    record("All OFFLINE: breakeven_risk == True",     snap["breakeven_risk"] == True)
+
+
+def suite_cumulative_state():
+    log("\\n── SUITE 4: Cumulative state (faults stack) ─────────────────────────")
+    reset_all()
+
+    # First fault
+    r1 = update_capacity(4, 12.0)  # OFFLINE
+    # Second fault on same machine — gets worse (already OFFLINE, stays OFFLINE)
+    r2 = update_capacity(4, 5.0)
+    record("Second fault on same machine keeps OFFLINE", r2["status"] == "OFFLINE")
+    record("total_T unchanged when already OFFLINE",
+           approx(r1["total_T"], r2["total_T"]))
+
+    # Fault on different machine stacks
+    r3 = update_capacity(3, 8.0)   # second machine OFFLINE
+    record("Second machine OFFLINE reduces total_T further",
+           r3["total_T"] < r1["total_T"])
+    record("Two OFFLINEs: total_T == 24.0", approx(r3["total_T"], 24.0))
+
+    # reset_all restores everything
+    reset_all()
+    snap = get_factory_snapshot()
+    record("reset_all() restores total_T to 40.0",    approx(snap["total_T"], 40.0))
+    record("reset_all() restores capacity_pct to 100", approx(snap["capacity_pct"], 100.0))
+    record("reset_all() sets breakeven_risk to False",  snap["breakeven_risk"] == False)
+    record("reset_all() sets all machines ONLINE",
+           all(m["status"] == "ONLINE" for m in MACHINES.values()))
+
+
+def suite_return_schema():
+    log("\\n── SUITE 5: Return dict schema ──────────────────────────────────────")
+    reset_all()
+    r = update_capacity(4, 12.0)
+
+    required_keys = {
+        "machine_id", "machine_name", "status", "rul",
+        "total_T", "total_PD", "machine_req", "capacity_pct", "breakeven_risk"
+    }
+    for key in required_keys:
+        record(f"Key '{key}' present in return dict", key in r)
+
+    record("machine_id is int",       isinstance(r["machine_id"], int))
+    record("machine_name is str",     isinstance(r["machine_name"], str))
+    record("status is str",           isinstance(r["status"], str))
+    record("breakeven_risk is bool",  isinstance(r["breakeven_risk"], bool))
+    record("rul is float",            isinstance(r["rul"], float))
+    record("capacity_pct is float",   isinstance(r["capacity_pct"], float))
+
+    # Invalid machine_id raises KeyError
+    try:
+        update_capacity(6, 10.0)
+        record("machine_id=6 raises KeyError", False, "no exception raised")
+    except KeyError:
+        record("machine_id=6 raises KeyError", True)
+
+    try:
+        update_capacity(0, 10.0)
+        record("machine_id=0 raises KeyError", False, "no exception raised")
+    except KeyError:
+        record("machine_id=0 raises KeyError", True)
+
+
+def print_summary():
+    total  = len(results)
+    passed = sum(1 for r in results if r["passed"])
+    failed = total - passed
+    log(f"\\n{'═' * 60}")
+    log(f"  RESULTS: {passed}/{total} passed   {failed} failed")
+    log(f"{'═' * 60}")
+    if failed:
+        log("\\n  Failed tests:")
+        for r in results:
+            if not r["passed"]:
+                log(f"    ✗ {r['name']}  {r['detail']}")
+
+
+def save_report():
+    report_dir = PROJECT_ROOT / "tests" / "results"
+    report_dir.mkdir(parents=True, exist_ok=True)
+    path = report_dir / "agent2_report.txt"
+    with open(path, "w") as f:
+        f.write(output_buffer.getvalue())
+    print(f"\\n  Report saved → {path.relative_to(PROJECT_ROOT)}")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--save", action="store_true")
+    args = parser.parse_args()
+
+    log("=" * 60)
+    log("  AGENT 2 — CAPACITY AGENT TEST SUITE")
+    log("=" * 60)
+
+    suite_constants()
+    suite_status_transitions()
+    suite_capacity_math()
+    suite_cumulative_state()
+    suite_return_schema()
+    print_summary()
+
+    if args.save:
+        save_report()

--- a/tests/test_integration12.py
+++ b/tests/test_integration12.py
@@ -1,0 +1,213 @@
+"""
+tests/test_integration.py
+Agent 1 + Agent 2 integration — uses a dummy oracle instead of the real DL model.
+No real predict_rul needed. Tests the full pipeline contract.
+
+Run: python tests/test_integration.py
+"""
+
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import numpy as np
+from agents.diagnostic_agent import translate_fault_to_tensor
+from agents.capacity_agent import update_capacity, reset_all, get_factory_snapshot
+
+
+# ── Dummy oracle — replaces Team DL's predict_rul() ──────────────────────────
+# Maps spike_value ranges to RUL buckets. High spike → low RUL.
+# Replace with the real function on integration day.
+
+def dummy_oracle(tensor: np.ndarray) -> float:
+    """
+    Deterministic stand-in for predict_rul(tensor).
+    Finds the max value across the tensor and maps it to a RUL range.
+    Real model: replace this entire function with dl_engine.predict_rul(tensor).
+    """
+    max_val = float(tensor.max())
+    if max_val > 0.90:
+        return 10.0    # HIGH spike → OFFLINE territory
+    elif max_val > 0.75:
+        return 22.0    # MEDIUM spike → DEGRADED territory
+    else:
+        return 55.0    # LOW spike → ONLINE territory
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+def test_high_fault_causes_offline():
+    """
+    A HIGH severity fault should produce RUL ≤ 15 and put the machine OFFLINE.
+    Pipeline: fault text → tensor → dummy_oracle → capacity_report
+    """
+    reset_all()
+    base = np.random.rand(50, 18).astype(np.float32) * 0.5  # baseline ~0.3-0.5
+
+    injected, spike_dict, _ = translate_fault_to_tensor(
+        base, "bearing temperature surge on Machine 4"
+    )
+
+    # Verify the tensor was actually modified
+    assert not np.array_equal(injected, base), "Tensor unchanged — spike not injected"
+
+    # Verify shape preserved for DL model
+    assert injected.shape == (50, 18), f"Wrong shape: {injected.shape}"
+    assert injected.dtype == np.float32, f"Wrong dtype: {injected.dtype}"
+
+    # Run through dummy oracle
+    rul = dummy_oracle(injected)
+    assert isinstance(rul, float), f"RUL must be float, got {type(rul)}"
+
+    # Feed into Agent 2
+    report = update_capacity(4, rul)
+
+    # HIGH fault → spike_value > 0.85 → oracle returns 10.0 → OFFLINE
+    assert report["status"] in ("OFFLINE", "DEGRADED"), (
+        f"HIGH fault should degrade machine, got {report['status']}"
+    )
+    assert report["capacity_pct"] < 100.0, "Capacity should have dropped"
+    assert report["breakeven_risk"] == True
+
+    print(f"  ✓ HIGH fault: sensor={spike_dict['sensor_id']}, "
+          f"RUL={rul}, status={report['status']}, cap={report['capacity_pct']}%")
+
+
+def test_output_dict_has_all_keys():
+    """
+    The dict returned by update_capacity() must have every key
+    that agent_loop.py passes to Floor Manager and Terminal UI.
+    """
+    reset_all()
+    base = np.random.rand(50, 18).astype(np.float32) * 0.5
+    injected, _, _ = translate_fault_to_tensor(base, "pressure spike in hydraulic line")
+    rul = dummy_oracle(injected)
+    report = update_capacity(2, rul)
+
+    required_keys = {
+        "machine_id", "machine_name", "status", "rul",
+        "total_T", "total_PD", "machine_req",
+        "capacity_pct", "breakeven_risk"
+    }
+    missing = required_keys - set(report.keys())
+    assert not missing, f"Missing keys in capacity report: {missing}"
+
+    # Verify types that Floor Manager's format() call depends on
+    assert isinstance(report["machine_id"],   int)
+    assert isinstance(report["machine_name"], str)
+    assert isinstance(report["capacity_pct"], float)
+    assert isinstance(report["breakeven_risk"], bool)
+
+    print(f"  ✓ Output dict schema valid: {list(report.keys())}")
+
+
+def test_stacked_faults_accumulate():
+    """
+    Three consecutive faults on different machines should progressively
+    drop capacity. Each call to update_capacity() must stack.
+    """
+    reset_all()
+    base = np.random.rand(50, 18).astype(np.float32) * 0.5
+
+    faults = [
+        ("bearing temperature surge on Machine 4", 4),
+        ("pressure spike in hydraulic line",        2),
+        ("vibration and shaking on CNC-Alpha",      1),
+    ]
+
+    prev_capacity = 100.0
+    for fault_text, machine_id in faults:
+        injected, spike_dict, _ = translate_fault_to_tensor(base, fault_text)
+        rul = dummy_oracle(injected)
+        report = update_capacity(machine_id, rul)
+
+        # Capacity should not increase after a fault
+        assert report["capacity_pct"] <= prev_capacity, (
+            f"Capacity went UP after fault on Machine {machine_id}: "
+            f"{prev_capacity}% → {report['capacity_pct']}%"
+        )
+        print(f"  ✓ Fault on M{machine_id} ({spike_dict['sensor_id']}): "
+              f"RUL={rul:.1f}, status={report['status']}, "
+              f"cap={report['capacity_pct']}%")
+        prev_capacity = report["capacity_pct"]
+
+    assert prev_capacity < 100.0, "Three faults should have dropped capacity below 100%"
+
+
+def test_tensor_shape_preserved_through_pipeline():
+    """
+    The tensor shape must be (50, 18) float32 at every stage.
+    This is the contract with Team DL's predict_rul().
+    """
+    reset_all()
+
+    fault_texts = [
+        "bearing temperature surge",
+        "pressure spike",
+        "vibration anomaly",
+        "coolant leak",
+        "RPM fluctuation",
+    ]
+
+    for text in fault_texts:
+        base = np.random.rand(50, 18).astype(np.float32)
+        injected, _, _ = translate_fault_to_tensor(base, text)
+        assert injected.shape == (50, 18), f"Shape broken for: '{text}'"
+        assert injected.dtype == np.float32, f"Dtype broken for: '{text}'"
+
+    print(f"  ✓ Shape (50, 18) float32 preserved for all {len(fault_texts)} fault types")
+
+
+def test_reset_clears_all_degradation():
+    """
+    After reset_all(), the factory must return to exactly the starting state,
+    regardless of how many faults were injected.
+    """
+    base = np.random.rand(50, 18).astype(np.float32) * 0.5
+
+    # Inject 5 faults
+    for mid in range(1, 6):
+        update_capacity(mid, 8.0)   # all OFFLINE
+
+    snap_degraded = get_factory_snapshot()
+    assert snap_degraded["capacity_pct"] == 0.0
+
+    reset_all()
+    snap_reset = get_factory_snapshot()
+
+    assert snap_reset["total_T"] == 40.0,      "total_T not restored"
+    assert snap_reset["capacity_pct"] == 100.0, "capacity_pct not restored"
+    assert snap_reset["breakeven_risk"] == False, "breakeven_risk not cleared"
+
+    print("  ✓ reset_all() fully restores factory to healthy baseline")
+
+
+# ── Runner ────────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("  INTEGRATION — Agent 1 + Agent 2 (dummy oracle)")
+    print("=" * 60)
+
+    tests = [
+        ("HIGH fault causes machine degradation",    test_high_fault_causes_offline),
+        ("Output dict has all required keys",         test_output_dict_has_all_keys),
+        ("Stacked faults accumulate correctly",       test_stacked_faults_accumulate),
+        ("Tensor shape preserved through pipeline",   test_tensor_shape_preserved_through_pipeline),
+        ("reset_all() clears all degradation",        test_reset_clears_all_degradation),
+    ]
+
+    passed = 0
+    for name, fn in tests:
+        print(f"\n── {name}")
+        try:
+            fn()
+            passed += 1
+        except AssertionError as e:
+            print(f"  ✗ FAILED: {e}")
+        except Exception as e:
+            print(f"  ✗ ERROR: {type(e).__name__}: {e}")
+
+    print(f"\n{'═' * 60}")
+    print(f"  RESULTS: {passed}/{len(tests)} passed")
+    print(f"{'═' * 60}")


### PR DESCRIPTION
## Summary
Adds **Agent 2 (Capacity Agent)** with full test coverage and integration with Agent 1.

---

## What’s included

### Agent 2 — Capacity Agent
- Pure Python (no LLM / external deps)
- State machine: ONLINE (>30) / DEGRADED (≤30) / OFFLINE (≤15)
- Computes: total_T, machine_req (ΣPD/T), capacity_pct, breakeven_risk
- Stateful (`MACHINES` dict), supports stacking
- Utilities: `reset_all()`, `get_all_machine_statuses()`, `get_factory_snapshot()`

### Tests
- **Unit tests (`test_agent2.py`)**
  - Covers transitions, capacity math, state stacking, schema
  - 30+ assertions, all passing, <1s runtime

- **Integration tests (`test_integration.py`)**
  - Agent 1 + Agent 2 with `dummy_oracle`
  - Covers degradation, schema, stacking, input shape `(50, 18)`
  - 5/5 passing (fallback path used due to rate limit)

---

## Not included (next steps)
- Agent 3 (Floor Manager)
- Orchestrator (`agent_loop.py`)
- Fallback cache + input guard
- Latency optimization (`thinking_budget=0`)
- Rate limit fix (see issue #XX)
- `NO_LIVE=1` for offline runs

---

## Verified
- Unit + integration tests passing
- `reset_all()` restores factory to baseline