### PR TITLE
terminal enhancement: sparklines, RUL bars, agent colours, ΣPD/T indi…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ matplotlib==3.10.0
 torch==2.10.0
 rich==14.3.3
 textual==8.2.1
+pyfiglet

--- a/terminal/app.py
+++ b/terminal/app.py
@@ -19,7 +19,8 @@ Run: python -m terminal.app
 """
 
 from textual.app import App, ComposeResult
-from textual.widgets import Header, Footer, Input, RichLog
+from textual.screen import Screen
+from textual.widgets import Header, Footer, Input, RichLog, Static
 from textual.binding import Binding
 from textual import work
 
@@ -38,6 +39,39 @@ from .ops_analytics import (
     compute_shift_health,
     compute_degradation_leaderboard,
 )
+
+
+class SplashScreen(Screen):
+    """2.5-second ASCII art splash shown before the main dashboard."""
+
+    CSS = """
+    SplashScreen {
+        align: center middle;
+        background: $background;
+    }
+    #splash-art {
+        width: auto;
+        content-align: center middle;
+        text-align: center;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        try:
+            import pyfiglet
+            art = pyfiglet.figlet_format("ForgeMind", font="slant")
+        except ImportError:
+            art = "FORGEMIND"
+        subtitle = (
+            "\n[dim]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[/dim]\n"
+            "[dim]  Predictive Maintenance Intelligence Platform  [/dim]\n"
+            "[dim]━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━[/dim]\n"
+            "\n[dim]Initializing factory systems...[/dim]"
+        )
+        yield Static(f"[bold green]{art}[/bold green]{subtitle}", id="splash-art", markup=True)
+
+    def on_mount(self) -> None:
+        self.set_timer(2.5, self.app.pop_screen)
 
 
 class FactoryApp(App):
@@ -108,13 +142,14 @@ class FactoryApp(App):
         yield Footer()
 
     def on_mount(self) -> None:
-        """Initialize display on startup."""
+        """Initialize display on startup, then overlay the splash screen."""
         self._refresh_ops_analytics()   # compute initial (all-nominal) analytics
         self._refresh_sensor_pane()
         self._refresh_capacity_pane()
         self._log("System", "Factory simulation online. All machines nominal.")
         self._log("System", "Type a fault description below to inject chaos.")
         self._log("System", "Keyboard: Ctrl+R = Reset | Ctrl+Q = Quit")
+        self.push_screen(SplashScreen())
 
     # ═════════════════════════════════════════════════════════════════════════
     # INPUT HANDLER

--- a/terminal/factory_state.py
+++ b/terminal/factory_state.py
@@ -86,6 +86,13 @@ class FactoryState:
     ))
     degradation_leaderboard: list = field(default_factory=list)
 
+    def __post_init__(self):
+        """Seed all machine sensor histories with baseline noise so sparklines show on startup."""
+        for mid in range(1, 6):
+            for _ in range(20):
+                baseline = np.random.uniform(0.3, 0.6, size=18).astype(np.float32)
+                self.push_machine_sensor_reading(mid, baseline)
+
     # ─────────────────────────────────────────────────────────────────────────
     # STATE UPDATE
     # ─────────────────────────────────────────────────────────────────────────

--- a/terminal/layout.py
+++ b/terminal/layout.py
@@ -38,29 +38,19 @@ def mini_sparkline(values: list, width: int = 20) -> str:
     return "".join(chars)
 
 
-def status_bar(status: str) -> str:
-    """Visual bar for machine status."""
-    return {
-        "ONLINE":   "████████",
-        "DEGRADED": "████░░░░",
-        "OFFLINE":  "░░░░░░░░",
-    }.get(status, "????????")
-
-
-def status_color(status: str) -> str:
-    """Color for machine status."""
-    return {
-        "ONLINE":   "green",
-        "DEGRADED": "yellow",
-        "OFFLINE":  "red",
-    }.get(status, "white")
+def rul_bar(rul: float, width: int = 20) -> str:
+    """Generate a filled progress bar scaled to RUL (max display = 200 cycles)."""
+    max_rul = 200.0
+    filled  = int((min(rul, max_rul) / max_rul) * width)
+    filled  = max(0, min(filled, width))
+    return "█" * filled + "░" * (width - filled)
 
 
 def rul_color(rul: float) -> str:
-    """Color based on RUL value."""
-    if rul > 30:
+    """Color based on RUL value — green >100, amber 15-100, red <15."""
+    if rul > 100:
         return "green"
-    elif rul > 15:
+    elif rul >= 15:
         return "yellow"
     else:
         return "red"
@@ -68,9 +58,9 @@ def rul_color(rul: float) -> str:
 
 def rul_label(rul: float) -> str:
     """Text label based on RUL value."""
-    if rul > 30:
+    if rul > 100:
         return "HEALTHY"
-    elif rul > 15:
+    elif rul >= 15:
         return "WARNING"
     else:
         return "CRITICAL"
@@ -183,21 +173,27 @@ class CapacityWidget(Static):
         lines.append(f"  {divider(42)}")
         lines.append("")
 
-        # ── SECTION 2: Machine bars ───────────────────────────────────────────
+        # ── SECTION 2: Machine bars (RUL-based progress bars) ────────────────
         for mid, machine in state.machines.items():
-            bar   = status_bar(machine.status)
-            color = status_color(machine.status)
-            lines.append(
-                f"  Machine {mid}: [{color}]{bar} {machine.status:>8s}[/{color}]"
-                f"  RUL: {machine.rul:.0f}"
-            )
+            bar   = rul_bar(machine.rul)
+            color = rul_color(machine.rul)
+            if machine.rul < 15:
+                lines.append(
+                    f"  [blink][bold red]Machine {mid}: {machine.name:<14s}[/bold red][/blink]"
+                    f"  [{color}]{bar}[/{color}]  RUL: {machine.rul:.0f}"
+                )
+            else:
+                lines.append(
+                    f"  Machine {mid}: {machine.name:<14s}"
+                    f"  [{color}]{bar}[/{color}]  RUL: {machine.rul:.0f}"
+                )
 
         # ── SECTION 3: Capacity metrics ───────────────────────────────────────
         lines.append("")
-        risk_flag = " [bold red]⚠ CRITICAL[/bold red]" if state.breakeven_risk else ""
+        spdt_color = "red" if state.machine_req >= 1.0 else "green"
         lines.append(
             f"  Capacity: {state.capacity_pct:.0f}% | "
-            f"ΣPD/T: {state.machine_req:.2f}{risk_flag}"
+            f"ΣPD/T: [{spdt_color}]{state.machine_req:.2f}[/{spdt_color}]"
         )
 
         # ── SECTION 4: Maintenance queue ─────────────────────────────────────
@@ -245,10 +241,10 @@ AGENT_COLORS = {
     "System":           "dim",
     "Chaos Engine":     "bold magenta",
     "Diagnostic Agent": "cyan",
-    "DL Oracle":        "bold green",
-    "Capacity Agent":   "yellow",
-    "Floor Manager":    "bold red",
-    "Ops Alert":        "bold red",      # ← new: cliff detection, saturation
+    "DL Oracle":        "yellow",
+    "Capacity Agent":   "white",
+    "Floor Manager":    "bold green",
+    "Ops Alert":        "bold red",
 }
 
 


### PR DESCRIPTION
…cator, splash screen

- Seed per-machine sensor history on startup so sparklines show immediately
- Replace static status bars with 20-char RUL progress bars (green/amber/red thresholds at >100/15-100/<15)
- Blinking red label for machines with RUL < 15
- ΣPD/T coloured green (<1.0) or red (≥1.0) inline in capacity line
- Agent log colours: DL Oracle→yellow, Capacity Agent→white, Floor Manager→bold green
- pyfiglet ASCII splash screen (2.5 s) before main dashboard loads